### PR TITLE
Do not ignore trait usage

### DIFF
--- a/ImportDetection/Sniffs/Imports/RequireImportsSniff.php
+++ b/ImportDetection/Sniffs/Imports/RequireImportsSniff.php
@@ -93,6 +93,9 @@ class RequireImportsSniff implements Sniff {
 	}
 
 	private function debug(string $message) {
+		if (! defined('PHP_CODESNIFFER_VERBOSITY')) {
+			return;
+		}
 		if (PHP_CODESNIFFER_VERBOSITY > 3) {
 			echo PHP_EOL . "RequireImportsSniff: DEBUG: $message" . PHP_EOL;
 		}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -33,6 +33,11 @@
 
     <!-- variables: https://github.com/sirbrillig/VariableAnalysis/ -->
     <rule ref="VariableAnalysis"/>
+    <rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis">
+        <properties>
+            <property name="allowUnusedCaughtExceptions" value="true"/>
+        </properties>
+    </rule>
     <rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable">
         <type>error</type>
     </rule>

--- a/tests/Sniffs/Imports/RequireImportsSniffTest.php
+++ b/tests/Sniffs/Imports/RequireImportsSniffTest.php
@@ -88,4 +88,15 @@ class RequireImportsSniffTest extends TestCase {
 		$expectedLines = [ 11 ];
 		$this->assertEquals($expectedLines, $lines);
 	}
+
+	public function testRequireImportsSniffCountsTraitUseAsUsage() {
+		$fixtureFile = __DIR__ . '/UsedTraitFixture.php';
+		$sniffFile = __DIR__ . '/../../../ImportDetection/Sniffs/Imports/RequireImportsSniff.php';
+		$helper = new SniffTestHelper();
+		$phpcsFile = $helper->prepareLocalFileForSniffs($sniffFile, $fixtureFile);
+		$phpcsFile->process();
+		$lines = $helper->getWarningLineNumbersFromFile($phpcsFile);
+		$expectedLines = [];
+		$this->assertEquals($expectedLines, $lines);
+	}
 }

--- a/tests/Sniffs/Imports/RequireImportsSniffTest.php
+++ b/tests/Sniffs/Imports/RequireImportsSniffTest.php
@@ -96,7 +96,7 @@ class RequireImportsSniffTest extends TestCase {
 		$phpcsFile = $helper->prepareLocalFileForSniffs($sniffFile, $fixtureFile);
 		$phpcsFile->process();
 		$lines = $helper->getWarningLineNumbersFromFile($phpcsFile);
-		$expectedLines = [];
+		$expectedLines = [10];
 		$this->assertEquals($expectedLines, $lines);
 	}
 }

--- a/tests/Sniffs/Imports/UsedTraitFixture.php
+++ b/tests/Sniffs/Imports/UsedTraitFixture.php
@@ -7,6 +7,7 @@ use Services\Appliance;
 
 class Toaster {
 	use Appliance;
+	use UnimportedSymbol; // this should be a warning
 	public function makeToast() {
 		$this->energize();
 	}

--- a/tests/Sniffs/Imports/UsedTraitFixture.php
+++ b/tests/Sniffs/Imports/UsedTraitFixture.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Services\Kitchen;
+
+use Services\Appliance;
+
+class Toaster {
+	use Appliance;
+	public function makeToast() {
+		$this->energize();
+	}
+}


### PR DESCRIPTION
Applying a trait is done via the `use <Trait>;` statement, which has the same signature as an import statement, but is inside of a class. This change allows the sniff to notice the difference between the two statements.

It also adds a `debug()` method to the class for future debugging use.

Fixes #5