### PR TITLE
Clarify ignoreUnimportedSymbols works for unused imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ You can ignore certain patterns by using the `ignoreUnimportedSymbols` config op
 </ruleset>
 ```
 
+Despite the name, you can also use the `ignoreUnimportedSymbols` pattern to ignore specific unused imports.
+
 ## Usage
 
 Most editors have a phpcs plugin available, but you can also run phpcs manually. To run phpcs on a file in your project, just use the command-line as follows (the `-s` causes the sniff code to be shown, which is very important for learning about an error).

--- a/tests/Sniffs/Imports/RequireImportsAllowedPatternFixture.php
+++ b/tests/Sniffs/Imports/RequireImportsAllowedPatternFixture.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace CAR_APP\Vehicles\Greatness;
 
 use function whitelisted_function;
+use function unused_function;
 
 class GreatClass {
 	private function activate() {

--- a/tests/Sniffs/Imports/RequireImportsSniffTest.php
+++ b/tests/Sniffs/Imports/RequireImportsSniffTest.php
@@ -56,13 +56,14 @@ class RequireImportsSniffTest extends TestCase {
 		$phpcsFile->process();
 		$lines = $helper->getWarningLineNumbersFromFile($phpcsFile);
 		$expectedLines = [
-			11,
+			7,
 			12,
+			13,
 		];
 		$this->assertEquals($expectedLines, $lines);
 	}
 
-	public function testRequireImportsSniffIgnoresAllowedImports() {
+	public function testRequireImportsSniffIgnoresWhitelistedUnimportedSymbols() {
 		$fixtureFile = __DIR__ . '/RequireImportsAllowedPatternFixture.php';
 		$sniffFile = __DIR__ . '/../../../ImportDetection/Sniffs/Imports/RequireImportsSniff.php';
 		$helper = new SniffTestHelper();
@@ -74,7 +75,23 @@ class RequireImportsSniffTest extends TestCase {
 		);
 		$phpcsFile->process();
 		$lines = $helper->getWarningLineNumbersFromFile($phpcsFile);
-		$expectedLines = [ 12 ];
+		$expectedLines = [ 7, 13 ];
+		$this->assertEquals($expectedLines, $lines);
+	}
+
+	public function testRequireImportsSniffIgnoresWhitelistedUnusedImports() {
+		$fixtureFile = __DIR__ . '/RequireImportsAllowedPatternFixture.php';
+		$sniffFile = __DIR__ . '/../../../ImportDetection/Sniffs/Imports/RequireImportsSniff.php';
+		$helper = new SniffTestHelper();
+		$phpcsFile = $helper->prepareLocalFileForSniffs($sniffFile, $fixtureFile);
+		$phpcsFile->ruleset->setSniffProperty(
+			'ImportDetection\Sniffs\Imports\RequireImportsSniff',
+			'ignoreUnimportedSymbols',
+			'/^(unused_function)$/'
+		);
+		$phpcsFile->process();
+		$lines = $helper->getWarningLineNumbersFromFile($phpcsFile);
+		$expectedLines = [ 12, 13 ];
 		$this->assertEquals($expectedLines, $lines);
 	}
 


### PR DESCRIPTION
It's not clear that `ignoreUnimportedSymbols` can be used to ignore unused imports as well. This adds a test to verify that it does and updates the documentation to make that clear.

Inspired by #13 