### PR TITLE
Add option to ignore globals in global namespace

### DIFF
--- a/ImportDetection/FileSymbolRecord.php
+++ b/ImportDetection/FileSymbolRecord.php
@@ -8,6 +8,7 @@ class FileSymbolRecord {
 	public $importedClasses = [];
 	public $importedSymbolRecords = [];
 	public $seenSymbols = [];
+	public $activeNamespace = null;
 
 	public function addImportedFunctions($names) {
 		$this->importedFunctions = array_merge($this->importedFunctions, $names);

--- a/ImportDetection/Sniffs/Imports/RequireImportsSniff.php
+++ b/ImportDetection/Sniffs/Imports/RequireImportsSniff.php
@@ -10,6 +10,7 @@ use PHP_CodeSniffer\Files\File;
 
 class RequireImportsSniff implements Sniff {
 	public $ignoreUnimportedSymbols = null;
+	public $ignoreGlobalsWhenInGlobalScope = false;
 
 	private $symbolRecordsByFile = [];
 
@@ -92,6 +93,14 @@ class RequireImportsSniff implements Sniff {
 			$this->markSymbolUsed($phpcsFile, $symbol);
 			return;
 		}
+		// If the symbol is global, we are in the global namespace, and
+		// configured to ignore global symbols in the global namespace,
+		// ignore it
+		if ($this->ignoreGlobalsWhenInGlobalScope && ! $symbol->isNamespaced()) {
+			$this->debug('found global symbol in global namespace: ' . $symbol->getName());
+			return;
+		}
+		$this->debug('found unimported symbol: ' . $symbol->getName());
 		$error = "Found unimported symbol '{$symbol->getName()}'.";
 		$phpcsFile->addWarning($error, $stackPtr, 'Symbol');
 	}

--- a/ImportDetection/Sniffs/Imports/RequireImportsSniff.php
+++ b/ImportDetection/Sniffs/Imports/RequireImportsSniff.php
@@ -96,7 +96,7 @@ class RequireImportsSniff implements Sniff {
 		// If the symbol is global, we are in the global namespace, and
 		// configured to ignore global symbols in the global namespace,
 		// ignore it
-		if ($this->ignoreGlobalsWhenInGlobalScope && ! $symbol->isNamespaced()) {
+		if ($this->ignoreGlobalsWhenInGlobalScope && ! $symbol->isNamespaced() && ! $this->symbolRecordsByFile[$phpcsFile->path]->activeNamespace) {
 			$this->debug('found global symbol in global namespace: ' . $symbol->getName());
 			return;
 		}

--- a/ImportDetection/Symbol.php
+++ b/ImportDetection/Symbol.php
@@ -42,6 +42,10 @@ class Symbol {
 		return $type === 'T_NS_SEPARATOR';
 	}
 
+	public function isNamespaced(): bool {
+		return count($this->tokens) > 1;
+	}
+
 	/**
 	 * @return string|null
 	 */

--- a/README.md
+++ b/README.md
@@ -108,6 +108,23 @@ You can ignore certain patterns by using the `ignoreUnimportedSymbols` config op
 
 Despite the name, you can also use the `ignoreUnimportedSymbols` pattern to ignore specific unused imports.
 
+## Ignoring Global Symbols in Global Namespace
+
+If a file is in the global namespace, then sometimes it may be unnecessary to import functions that are also global. If you'd like to ignore global symbol use in the global namespace, you can enable the `ignoreGlobalsWhenInGlobalScope` option, like this:
+
+```xml
+<?xml version="1.0"?>
+<ruleset name="MyStandard">
+ <description>My library.</description>
+ <rule ref="ImportDetection"/>
+ <rule ref="ImportDetection.Imports.RequireImports">
+   <properties>
+    <property name="ignoreGlobalsWhenInGlobalScope" value="true"/>
+  </properties>
+ </rule>
+</ruleset>
+```
+
 ## Usage
 
 Most editors have a phpcs plugin available, but you can also run phpcs manually. To run phpcs on a file in your project, just use the command-line as follows (the `-s` causes the sniff code to be shown, which is very important for learning about an error).

--- a/tests/Sniffs/Imports/GlobalNamespaceFixture.php
+++ b/tests/Sniffs/Imports/GlobalNamespaceFixture.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+use MagicCode\Snacks;
+use function CAR_APP\Functions\whitelisted_function;
+use function CAR_APP\Functions\unused_function; // unused
+use function CAR_APP\Functions\{ three_function, four_function }; // unused
+use function Other_App\{ one_function, two_function };
+
+class GreatClass {
+	private function activate() {
+		whitelisted_function();
+		another_whitelisted_function(); // unimported
+		non_whitelisted_function(); // unimported
+		one_function();
+		two_function();
+		three_function();
+		Snacks\do_that_magic();
+		Cookies\eat_them(); // unimported
+	}
+}

--- a/tests/Sniffs/Imports/RequireImportsSniffTest.php
+++ b/tests/Sniffs/Imports/RequireImportsSniffTest.php
@@ -209,6 +209,27 @@ class RequireImportsSniffTest extends TestCase {
 		$this->assertEquals($expectedLines, $lines);
 	}
 
+	public function testRequireImportsSniffFindsGlobalSymbolsInNamespaceIfConfigured() {
+		$fixtureFile = __DIR__ . '/RequireImportsAllowedPatternFixture.php';
+		$sniffFile = __DIR__ . '/../../../ImportDetection/Sniffs/Imports/RequireImportsSniff.php';
+		$helper = new SniffTestHelper();
+		$phpcsFile = $helper->prepareLocalFileForSniffs($sniffFile, $fixtureFile);
+		$phpcsFile->ruleset->setSniffProperty(
+			'ImportDetection\Sniffs\Imports\RequireImportsSniff',
+			'ignoreGlobalsWhenInGlobalScope',
+			'true'
+		);
+		$phpcsFile->process();
+		$lines = $helper->getWarningLineNumbersFromFile($phpcsFile);
+		$expectedLines = [
+			8,
+			9,
+			15,
+			16,
+		];
+		$this->assertEquals($expectedLines, $lines);
+	}
+
 	public function testRequireImportsDoesNotBleedToMultipleFiles() {
 		$fixtureFile = __DIR__ . '/MultipleFilesFixtures';
 		$sniffFile = __DIR__ . '/../../../ImportDetection/Sniffs/Imports/RequireImportsSniff.php';

--- a/tests/Sniffs/Imports/RequireImportsSniffTest.php
+++ b/tests/Sniffs/Imports/RequireImportsSniffTest.php
@@ -172,6 +172,43 @@ class RequireImportsSniffTest extends TestCase {
 		$this->assertEquals($expectedLines, $lines);
 	}
 
+	public function testRequireImportsSniffFindsGlobalSymbolsIfNoConfig() {
+		$fixtureFile = __DIR__ . '/GlobalNamespaceFixture.php';
+		$sniffFile = __DIR__ . '/../../../ImportDetection/Sniffs/Imports/RequireImportsSniff.php';
+		$helper = new SniffTestHelper();
+		$phpcsFile = $helper->prepareLocalFileForSniffs($sniffFile, $fixtureFile);
+		$phpcsFile->process();
+		$lines = $helper->getWarningLineNumbersFromFile($phpcsFile);
+		$expectedLines = [
+			6,
+			7,
+			13,
+			14,
+			19,
+		];
+		$this->assertEquals($expectedLines, $lines);
+	}
+
+	public function testRequireImportsSniffIgnoresGlobalSymbolsIfConfigured() {
+		$fixtureFile = __DIR__ . '/GlobalNamespaceFixture.php';
+		$sniffFile = __DIR__ . '/../../../ImportDetection/Sniffs/Imports/RequireImportsSniff.php';
+		$helper = new SniffTestHelper();
+		$phpcsFile = $helper->prepareLocalFileForSniffs($sniffFile, $fixtureFile);
+		$phpcsFile->ruleset->setSniffProperty(
+			'ImportDetection\Sniffs\Imports\RequireImportsSniff',
+			'ignoreGlobalsWhenInGlobalScope',
+			'true'
+		);
+		$phpcsFile->process();
+		$lines = $helper->getWarningLineNumbersFromFile($phpcsFile);
+		$expectedLines = [
+			6,
+			7,
+			19,
+		];
+		$this->assertEquals($expectedLines, $lines);
+	}
+
 	public function testRequireImportsDoesNotBleedToMultipleFiles() {
 		$fixtureFile = __DIR__ . '/MultipleFilesFixtures';
 		$sniffFile = __DIR__ . '/../../../ImportDetection/Sniffs/Imports/RequireImportsSniff.php';


### PR DESCRIPTION
This adds the config option `ignoreGlobalsWhenInGlobalScope`. If it is set,
the sniff will not report a warning for unimported symbols which have no
namespace.

Fixes #4

- [x] Document this option