### PR TITLE
Differentiate between namespace and class

### DIFF
--- a/ImportDetection/Sniffs/Imports/RequireImportsSniff.php
+++ b/ImportDetection/Sniffs/Imports/RequireImportsSniff.php
@@ -281,8 +281,9 @@ class RequireImportsSniff implements Sniff {
 
 	private function getRecordedImportedSymbolMatchingSymbol(File $phpcsFile, Symbol $symbol) {
 		foreach ($this->symbolRecordsByFile[$phpcsFile->path]->importedSymbolRecords as $record) {
-			$this->debug("comparing symbol {$symbol->getTopLevelNamespace()} to alias {$record->getAlias()}");
-			if ($record->getAlias() === $symbol->getTopLevelNamespace()) {
+			$namespaceOrAlias = $symbol->getTopLevelNamespace() ?? $symbol->getAlias();
+			$this->debug("comparing symbol {$namespaceOrAlias} to alias {$record->getAlias()}");
+			if ($record->getAlias() === $namespaceOrAlias) {
 				return $record;
 			}
 		}

--- a/ImportDetection/Sniffs/Imports/RequireImportsSniff.php
+++ b/ImportDetection/Sniffs/Imports/RequireImportsSniff.php
@@ -152,12 +152,20 @@ class RequireImportsSniff implements Sniff {
 
 	private function isSymbolDefined(File $phpcsFile, Symbol $symbol): bool {
 		$namespace = $symbol->getTopLevelNamespace();
-		// If the symbol's namespace is imported or defined, ignore it
+		// If the symbol's namespace is imported, ignore it
 		if ($namespace) {
-			return $this->isNamespaceImportedOrDefined($phpcsFile, $namespace);
+			return $this->isNamespaceImported($phpcsFile, $namespace);
 		}
 		// If the symbol has no namespace and is itself is imported or defined, ignore it
 		return $this->isNamespaceImportedOrDefined($phpcsFile, $symbol->getName());
+	}
+
+	private function isNamespaceImported(File $phpcsFile, string $namespace): bool {
+		return (
+			$this->isClassImported($phpcsFile, $namespace)
+			|| $this->isFunctionImported($phpcsFile, $namespace)
+			|| $this->isConstImported($phpcsFile, $namespace)
+		);
 	}
 
 	private function isNamespaceImportedOrDefined(File $phpcsFile, string $namespace): bool {

--- a/ImportDetection/Symbol.php
+++ b/ImportDetection/Symbol.php
@@ -50,6 +50,9 @@ class Symbol {
 	 * @return string|null
 	 */
 	public function getTopLevelNamespace() {
+		if (! $this->isNamespaced()) {
+			return null;
+		}
 		return $this->tokens[0]['content'] ?? null;
 	}
 

--- a/tests/Sniffs/Imports/ClassUsedAsNamespaceFixture.php
+++ b/tests/Sniffs/Imports/ClassUsedAsNamespaceFixture.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Movies;
+
+class Totoro {
+  public function playMovie() {
+    Totoro\startMoviePlayer(); // this should be a warning that `Totoro` is not imported
+  }
+}

--- a/tests/Sniffs/Imports/RequireImportsSniffTest.php
+++ b/tests/Sniffs/Imports/RequireImportsSniffTest.php
@@ -298,4 +298,17 @@ class RequireImportsSniffTest extends TestCase {
 		];
 		$this->assertEquals($expectedLines, $linesByFile);
 	}
+
+	public function testRequireImportsFindsUnimportedNamespaceIdenticalToClass() {
+		$fixtureFile = __DIR__ . '/ClassUsedAsNamespaceFixture.php';
+		$sniffFile = __DIR__ . '/../../../ImportDetection/Sniffs/Imports/RequireImportsSniff.php';
+		$helper = new SniffTestHelper();
+		$phpcsFile = $helper->prepareLocalFileForSniffs($sniffFile, $fixtureFile);
+		$phpcsFile->process();
+		$lines = $helper->getWarningLineNumbersFromFile($phpcsFile);
+		$expectedLines = [
+			7,
+		];
+		$this->assertEquals($expectedLines, $lines);
+	}
 }


### PR DESCRIPTION
When a namespace is used to prefix a used symbol (eg: `Foo\bar()`), currently we look for an imported alias matching the prefix (eg: `use Foo`), but we also look for a defined symbol matching the alias (eg: `class Foo`), which is invalid.

Fixes #3