### PR TITLE
Move predefined check after imported symbol check

### DIFF
--- a/ImportDetection/Sniffs/Imports/RequireImportsSniff.php
+++ b/ImportDetection/Sniffs/Imports/RequireImportsSniff.php
@@ -78,6 +78,13 @@ class RequireImportsSniff implements Sniff {
 			$this->debug('found symbol inside an import: ' . $symbol->getName());
 			return;
 		}
+		// If the symbol's namespace is imported or defined, ignore it
+		// If the symbol has no namespace and is itself is imported or defined, ignore it
+		if ($this->isSymbolDefined($phpcsFile, $symbol)) {
+			$this->debug('found defined symbol: ' . $symbol->getName());
+			$this->markSymbolUsed($phpcsFile, $symbol);
+			return;
+		}
 		// If the symbol is predefined, ignore it
 		if ($helper->isPredefinedConstant($phpcsFile, $stackPtr) || $helper->isBuiltInFunction($phpcsFile, $stackPtr)) {
 			$this->debug('found predefined symbol: ' . $symbol->getName());
@@ -86,13 +93,6 @@ class RequireImportsSniff implements Sniff {
 		// If this symbol is a predefined typehint, ignore it
 		if ($helper->isPredefinedTypehint($phpcsFile, $stackPtr)) {
 			$this->debug('found typehint symbol: ' . $symbol->getName());
-			return;
-		}
-		// If the symbol's namespace is imported or defined, ignore it
-		// If the symbol has no namespace and is itself is imported or defined, ignore it
-		if ($this->isSymbolDefined($phpcsFile, $symbol)) {
-			$this->debug('found defined symbol: ' . $symbol->getName());
-			$this->markSymbolUsed($phpcsFile, $symbol);
 			return;
 		}
 		// If the symbol is global, we are in the global namespace, and

--- a/tests/Sniffs/Imports/FileKeywordFixture.php
+++ b/tests/Sniffs/Imports/FileKeywordFixture.php
@@ -1,0 +1,7 @@
+<?php
+
+use Foo\Bar\File;
+
+function doSomething(File $myFile) {
+  echo $myFile;
+}

--- a/tests/Sniffs/Imports/RequireImportsSniffTest.php
+++ b/tests/Sniffs/Imports/RequireImportsSniffTest.php
@@ -336,4 +336,15 @@ class RequireImportsSniffTest extends TestCase {
 		];
 		$this->assertEquals($expectedLines, $lines);
 	}
+
+	public function testRequireImportsSniffTreatsFileImportAsUsedWhenUsed() {
+		$fixtureFile = __DIR__ . '/FileKeywordFixture.php';
+		$sniffFile = __DIR__ . '/../../../ImportDetection/Sniffs/Imports/RequireImportsSniff.php';
+		$helper = new SniffTestHelper();
+		$phpcsFile = $helper->prepareLocalFileForSniffs($sniffFile, $fixtureFile);
+		$phpcsFile->process();
+		$lines = $helper->getWarningLineNumbersFromFile($phpcsFile);
+		$expectedLines = [];
+		$this->assertEquals($expectedLines, $lines);
+	}
 }


### PR DESCRIPTION
We check for predefined symbols before we check for imported symbols, which means that if we import a symbol which matches a predefined symbol, the imported symbol will be ignored, and will then be reported as unused incorrectly.

This change inverts that order such that imported symbols take precedence.

Fixes #25 