### PR TITLE
feat(detection) Detect symbol of kind `abc\{def\ghi, klm\nop}`

### DIFF
--- a/ImportDetection/Symbol.php
+++ b/ImportDetection/Symbol.php
@@ -6,8 +6,9 @@ namespace ImportDetection;
 class Symbol {
 	private $tokens;
 	private $isUsed;
+	private $alias;
 
-	public function __construct(array $tokens) {
+	public function __construct(array $tokens, self $alias = null) {
 		if (empty($tokens)) {
 			throw new \Exception('Cannot construct Symbol with no tokens');
 		}
@@ -18,6 +19,7 @@ class Symbol {
 		}
 		$this->tokens = $tokens;
 		$this->isUsed = false;
+		$this->alias = $alias;
 	}
 
 	public static function getTokenWithPosition(array $token, int $stackPtr): array {
@@ -34,6 +36,10 @@ class Symbol {
 	}
 
 	public function getAlias(): string {
+		if ($this->alias) {
+			return $this->alias->getName();
+		}
+
 		return $this->tokens[count($this->tokens) - 1]['content'];
 	}
 

--- a/tests/Sniffs/Imports/ClassFixtures.php
+++ b/tests/Sniffs/Imports/ClassFixtures.php
@@ -1,0 +1,15 @@
+<?php
+use NamespaceName\{
+	A, // used line 13
+	C\D, // not used
+	X\Y as Z, // used line 14
+};
+use NamespaceName\{
+	B, // not used
+	E\F, // used line 15
+	I\J as H, // not used
+};
+
+A::class;
+Z::class;
+F::class;

--- a/tests/Sniffs/Imports/RequireImportsSniffTest.php
+++ b/tests/Sniffs/Imports/RequireImportsSniffTest.php
@@ -323,6 +323,33 @@ class RequireImportsSniffTest extends TestCase {
 		$this->assertEquals($expectedLines, $lines);
 	}
 
+	public function testRequireImportsNoticesUnusedClasses() {
+		$fixtureFile = __DIR__ . '/ClassFixtures.php';
+		$sniffFile = __DIR__ . '/../../../ImportDetection/Sniffs/Imports/RequireImportsSniff.php';
+		$helper = new SniffTestHelper();
+		$phpcsFile = $helper->prepareLocalFileForSniffs($sniffFile, $fixtureFile);
+		$phpcsFile->process();
+
+		$warnings = $phpcsFile->getWarnings();
+		$messages = $helper->getWarningMessageRecords($warnings);
+		$messages = array_values(array_filter($messages, function ($message) {
+			return $message->source === 'ImportDetection.Imports.RequireImports.Import';
+		}));
+		$lines = array_map(function ($message) {
+			return $message->rowNumber;
+		}, $messages);
+		$expectedLines = [
+			2,
+			7,
+			7,
+		];
+		$this->assertEquals($expectedLines, $lines);
+		$this->assertCount(3, $messages);
+		$this->assertEquals('Found unused symbol \'NamespaceName\C\D\'.', $messages[0]->message);
+		$this->assertEquals('Found unused symbol \'NamespaceName\B\'.', $messages[1]->message);
+		$this->assertEquals('Found unused symbol \'NamespaceName\I\J\'.', $messages[2]->message);
+	}
+
 	public function testRequireImportsNoticesUnusedConstants() {
 		$fixtureFile = __DIR__ . '/ConstantsFixure.php';
 		$sniffFile = __DIR__ . '/../../../ImportDetection/Sniffs/Imports/RequireImportsSniff.php';


### PR DESCRIPTION
This patch updates `getImportedSymbolsFromGroupStatement` to
understand namespaced symbols (`x\y`) inside a group (`{…}`), like
`abc\{def\ghi, klm\nop}`.

This patch also adds, for the sake of completeness, an alias property
on `Symbol`, so that not only the last strings of a namespaced name is
considered as an alias, but the real alias string (`as x`, here `x`)
can be used as an alias if declared.