### PR TITLE
Add test case for automatic string conversion

### DIFF
--- a/tests/Sniffs/Imports/RequireImportsSniffTest.php
+++ b/tests/Sniffs/Imports/RequireImportsSniffTest.php
@@ -185,7 +185,7 @@ class RequireImportsSniffTest extends TestCase {
 		);
 		$phpcsFile->process();
 		$lines = $helper->getWarningLineNumbersFromFile($phpcsFile);
-		$expectedLines = [ 38, 61, 63 ];
+		$expectedLines = [ 38, 61, 63, 80 ];
 		$this->assertEquals($expectedLines, $lines);
 	}
 

--- a/tests/Sniffs/Imports/RequireImportsSniffTest.php
+++ b/tests/Sniffs/Imports/RequireImportsSniffTest.php
@@ -169,6 +169,7 @@ class RequireImportsSniffTest extends TestCase {
 			61,
 			63,
 			74,
+			80,
 		];
 		$this->assertEquals($expectedLines, $lines);
 	}

--- a/tests/Sniffs/Imports/WordPressFixture.php
+++ b/tests/Sniffs/Imports/WordPressFixture.php
@@ -75,3 +75,6 @@ class CoolPlugin {
 		);
 	}
 }
+
+function foo() {}
+add_action('init', foo);


### PR DESCRIPTION
Here we add a test case to be sure that unquoted string conversion doesn't count as a defined symbol.

This may be confusing because if PHP encounters an undefined symbol, it will issue a warning and try converting it to a string. Because of this fallback, using unquoted strings may seem like valid PHP, but it's not doing what you might think it's doing; it's actually still using a
string. In a future version of php, this fallback may be removed, so it's recommended to avoid it (see the warning here: https://www.php.net/manual/en/migration72.deprecated.php).

Props @zanona for #32 which brought this up!