### PR TITLE
Composer: update PHPCS Composer plugin dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require-dev": {
         "sirbrillig/phpcs-variable-analysis": "^2.0.1",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.6",
         "phpunit/phpunit": "^6.4",
         "limedeck/phpunit-detailed-printer": "^3.1",
         "squizlabs/php_codesniffer": "3.3.0"


### PR DESCRIPTION
The DealerDirect Composer plugin has released version `0.6.2` by now.

As Composer treats minors < 1.0 as majors, updating to this version requires an update to the `composer.json` requirements.

> For pre-1.0 versions it also acts with safety in mind and treats `^0.3` as `>=0.3.0 <0.4.0`.

Refs:
* https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases/tag/v0.6.0
* https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases/tag/v0.6.1
* https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases/tag/v0.6.2
* https://getcomposer.org/doc/articles/versions.md#caret-version-range-