### PR TITLE
Composer: PHPCS is a production dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ class Car {
 To use these rules in a project which is set up using [composer](https://href.li/?https://getcomposer.org/), we recommend using the [phpcodesniffer-composer-installer library](https://href.li/?https://github.com/DealerDirect/phpcodesniffer-composer-installer) which will automatically use all installed standards in the current project with the composer type `phpcodesniffer-standard` when you run phpcs.
 
 ```
-composer require --dev squizlabs/php_codesniffer dealerdirect/phpcodesniffer-composer-installer
-composer require --dev sirbrillig/phpcs-import-detection
+composer require --dev sirbrillig/phpcs-import-detection dealerdirect/phpcodesniffer-composer-installer
 ```
 
 ## Configuration

--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,13 @@
         "test": "./vendor/bin/phpunit"
     },
     "require" : {
-        "php" : "^7.0"
+        "php" : "^7.0",
+        "squizlabs/php_codesniffer": "^3.3.0"
     },
     "require-dev": {
         "sirbrillig/phpcs-variable-analysis": "^2.0.1",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.6",
         "phpunit/phpunit": "^6.4",
-        "limedeck/phpunit-detailed-printer": "^3.1",
-        "squizlabs/php_codesniffer": "3.3.0"
+        "limedeck/phpunit-detailed-printer": "^3.1"
     }
 }


### PR DESCRIPTION
PHP_CodeSniffer is a dependency for this external standard to be able to run, so should be in `require`, not `require-dev`.

This also makes sure that people won't be able to try and run the standard with incompatible PHPCS versions.

Includes making the version requirement more flexible (not fixed to one version `3.3.0` only).