### PR TITLE
fix: Support mixed typehint

### DIFF
--- a/ImportDetection/SniffHelpers.php
+++ b/ImportDetection/SniffHelpers.php
@@ -33,6 +33,7 @@ class SniffHelpers {
 		$allTypehints = [
 			'bool',
 			'string',
+			'mixed',
 			'object',
 			'int',
 			'float',

--- a/tests/Sniffs/Imports/Fixtures/RequireImportsFixture.php
+++ b/tests/Sniffs/Imports/Fixtures/RequireImportsFixture.php
@@ -107,3 +107,7 @@ define(WHATEVER, 'some words');
 function engageMagic(object $foobar) {
 	echo $foobar;
 }
+
+function engageMoreMagic(mixed $foobar) {
+	echo $foobar;
+}


### PR DESCRIPTION
Adds support for the `mixed` pseudo type, [new in PHP 8](https://php.watch/versions/8.0/mixed-type).