### PR TITLE
PHP 8.2 | Fix deprecated embedded variables in text strings

### DIFF
--- a/ImportDetection/Sniffs/Imports/RequireImportsSniff.php
+++ b/ImportDetection/Sniffs/Imports/RequireImportsSniff.php
@@ -125,7 +125,7 @@ class RequireImportsSniff implements Sniff {
 
 		$wordPressPatterns = $this->getIgnoredWordPressSymbolPatterns();
 		$matchingWordPressPatterns = array_values(array_filter($wordPressPatterns, function (string $pattern) use ($symbol): bool {
-			return $this->doesSymbolMatchPattern($symbol, "/${pattern}/");
+			return $this->doesSymbolMatchPattern($symbol, "/{$pattern}/");
 		}));
 		return count($matchingWordPressPatterns) > 0;
 	}


### PR DESCRIPTION
PHP 8.2 will deprecate two of the four currently supported syntaxes for embedding variables in double quoted text string/heredocs.

This library contains one use of embedded variables using braces after the dollar sign (`"${foo}"`), which is one of the deprecated forms.

This commit fixes that.

Refs:
* https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation